### PR TITLE
[ADO #10] Add a second address for user

### DIFF
--- a/packages/evershop/src/components/frontStore/checkout/Shipment.tsx
+++ b/packages/evershop/src/components/frontStore/checkout/Shipment.tsx
@@ -13,10 +13,12 @@ import {
   useCheckoutDispatch
 } from '@components/frontStore/checkout/CheckoutContext.js';
 import { ShippingMethods } from '@components/frontStore/checkout/shipment/ShippingMethods.js';
+import { useCustomer, ExtendedCustomerAddress } from '@components/frontStore/customer/CustomerContext.js';
 import CustomerAddressForm from '@components/frontStore/customer/address/addressForm/Index.js';
+import { SavedAddressSelector } from '@components/frontStore/customer/address/SavedAddressSelector.js';
 import { _ } from '@evershop/evershop/lib/locale/translate/_';
 import { MapPin } from 'lucide-react';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { toast } from 'react-toastify';
 
@@ -43,6 +45,13 @@ export function Shipment() {
   } = useCartDispatch();
   const { form } = useCheckout();
   const { updateCheckoutData } = useCheckoutDispatch();
+  const { customer } = useCustomer();
+  const [selectedSavedAddressUuid, setSelectedSavedAddressUuid] = useState<
+    string | undefined
+  >(undefined);
+
+  const savedAddresses: ExtendedCustomerAddress[] =
+    customer?.addresses ?? [];
 
   // Use useWatch for better performance and cleaner code
   const watchedShippingAddress = useWatch({
@@ -125,6 +134,53 @@ export function Shipment() {
     };
   }, [watchedShippingAddress, dirtyFields.shippingAddress]); // Clean dependency array
 
+  const handleSavedAddressSelect = (
+    addr: ExtendedCustomerAddress | null
+  ) => {
+    if (addr === null) {
+      // "Enter new address" selected — clear fields and unset selected
+      setSelectedSavedAddressUuid(undefined);
+      form.setValue('shippingAddress.full_name', '');
+      form.setValue('shippingAddress.telephone', '');
+      form.setValue('shippingAddress.address_1', '');
+      form.setValue('shippingAddress.address_2', '');
+      form.setValue('shippingAddress.city', '');
+      form.setValue('shippingAddress.province', '');
+      form.setValue('shippingAddress.country', '');
+      form.setValue('shippingAddress.postcode', '');
+    } else {
+      setSelectedSavedAddressUuid(addr.uuid);
+      form.setValue('shippingAddress.full_name', addr.fullName ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('shippingAddress.telephone', addr.telephone ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('shippingAddress.address_1', addr.address1 ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('shippingAddress.address_2', addr.address2 ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('shippingAddress.city', addr.city ?? '', {
+        shouldDirty: true
+      });
+      form.setValue(
+        'shippingAddress.province',
+        addr.province?.code ?? '',
+        { shouldDirty: true }
+      );
+      form.setValue(
+        'shippingAddress.country',
+        addr.country?.code ?? '',
+        { shouldDirty: true }
+      );
+      form.setValue('shippingAddress.postcode', addr.postcode ?? '', {
+        shouldDirty: true
+      });
+    }
+  };
+
   const updateShipment = async (method: { code: string; name: string }) => {
     try {
       const validate = await form.trigger('shippingAddress');
@@ -157,6 +213,13 @@ export function Shipment() {
           </CardTitle>
         </CardHeader>
         <CardContent>
+          {savedAddresses.length > 0 && (
+            <SavedAddressSelector
+              addresses={savedAddresses}
+              onSelect={handleSavedAddressSelect}
+              selectedAddressUuid={selectedSavedAddressUuid}
+            />
+          )}
           <CustomerAddressForm
             areaId="checkoutShippingAddressForm"
             fieldNamePrefix="shippingAddress"

--- a/packages/evershop/src/components/frontStore/checkout/payment/BillingAddress.tsx
+++ b/packages/evershop/src/components/frontStore/checkout/payment/BillingAddress.tsx
@@ -14,7 +14,9 @@ import {
   useCheckout,
   useCheckoutDispatch
 } from '@components/frontStore/checkout/CheckoutContext.js';
+import { useCustomer, ExtendedCustomerAddress } from '@components/frontStore/customer/CustomerContext.js';
 import CustomerAddressForm from '@components/frontStore/customer/address/addressForm/Index.js';
+import { SavedAddressSelector } from '@components/frontStore/customer/address/SavedAddressSelector.js';
 import { _ } from '@evershop/evershop/lib/locale/translate/_';
 import {
   Address,
@@ -36,12 +38,64 @@ export function BillingAddress({
 }) {
   const { form, checkoutData } = useCheckout();
   const { updateCheckoutData } = useCheckoutDispatch();
+  const { customer } = useCustomer();
   const {
     setValue,
     getValues,
     trigger,
     formState: { disabled }
   } = form;
+
+  const savedAddresses: ExtendedCustomerAddress[] =
+    customer?.addresses ?? [];
+  const [selectedSavedBillingAddressUuid, setSelectedSavedBillingAddressUuid] =
+    useState<string | undefined>(undefined);
+
+  const handleSavedBillingAddressSelect = (
+    addr: ExtendedCustomerAddress | null
+  ) => {
+    if (addr === null) {
+      setSelectedSavedBillingAddressUuid(undefined);
+      form.setValue('billingAddress.full_name', '');
+      form.setValue('billingAddress.telephone', '');
+      form.setValue('billingAddress.address_1', '');
+      form.setValue('billingAddress.address_2', '');
+      form.setValue('billingAddress.city', '');
+      form.setValue('billingAddress.province', '');
+      form.setValue('billingAddress.country', '');
+      form.setValue('billingAddress.postcode', '');
+    } else {
+      setSelectedSavedBillingAddressUuid(addr.uuid);
+      form.setValue('billingAddress.full_name', addr.fullName ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('billingAddress.telephone', addr.telephone ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('billingAddress.address_1', addr.address1 ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('billingAddress.address_2', addr.address2 ?? '', {
+        shouldDirty: true
+      });
+      form.setValue('billingAddress.city', addr.city ?? '', {
+        shouldDirty: true
+      });
+      form.setValue(
+        'billingAddress.province',
+        addr.province?.code ?? '',
+        { shouldDirty: true }
+      );
+      form.setValue(
+        'billingAddress.country',
+        addr.country?.code ?? '',
+        { shouldDirty: true }
+      );
+      form.setValue('billingAddress.postcode', addr.postcode ?? '', {
+        shouldDirty: true
+      });
+    }
+  };
 
   const shippingAddress = useWatch({
     control: form.control,
@@ -134,6 +188,15 @@ export function BillingAddress({
                     {!useSameAddress && (
                       <ItemDescription className="text-inherit mt-3 overflow-visible">
                         <div className="text-inherit bg-white">
+                          {savedAddresses.length > 0 && (
+                            <SavedAddressSelector
+                              addresses={savedAddresses}
+                              onSelect={handleSavedBillingAddressSelect}
+                              selectedAddressUuid={
+                                selectedSavedBillingAddressUuid
+                              }
+                            />
+                          )}
                           <CustomerAddressForm
                             areaId="checkoutBillingAddressForm"
                             fieldNamePrefix="billingAddress"
@@ -157,6 +220,13 @@ export function BillingAddress({
             ) : (
               <ItemDescription className="text-inherit mt-3 overflow-visible">
                 <div className="text-inherit bg-white">
+                  {savedAddresses.length > 0 && (
+                    <SavedAddressSelector
+                      addresses={savedAddresses}
+                      onSelect={handleSavedBillingAddressSelect}
+                      selectedAddressUuid={selectedSavedBillingAddressUuid}
+                    />
+                  )}
                   <CustomerAddressForm
                     areaId="checkoutBillingAddressForm"
                     fieldNamePrefix="billingAddress"

--- a/packages/evershop/src/components/frontStore/customer/address/SavedAddressSelector.tsx
+++ b/packages/evershop/src/components/frontStore/customer/address/SavedAddressSelector.tsx
@@ -1,0 +1,94 @@
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemTitle
+} from '@components/common/ui/Item.js';
+import { Label } from '@components/common/ui/Label.js';
+import {
+  RadioGroup,
+  RadioGroupItem
+} from '@components/common/ui/RadioGroup.js';
+import { _ } from '@evershop/evershop/lib/locale/translate/_';
+import { ExtendedCustomerAddress } from '@components/frontStore/customer/CustomerContext.js';
+import React from 'react';
+
+interface SavedAddressSelectorProps {
+  addresses: ExtendedCustomerAddress[];
+  onSelect: (address: ExtendedCustomerAddress | null) => void;
+  selectedAddressUuid?: string;
+}
+
+export function SavedAddressSelector({
+  addresses,
+  onSelect,
+  selectedAddressUuid
+}: SavedAddressSelectorProps) {
+  if (!addresses || addresses.length === 0) {
+    return null;
+  }
+
+  const handleValueChange = (value: string) => {
+    if (value === 'new') {
+      onSelect(null);
+    } else {
+      const selected = addresses.find((addr) => addr.uuid === value);
+      if (selected) {
+        onSelect(selected);
+      }
+    }
+  };
+
+  const currentValue = selectedAddressUuid ?? 'new';
+
+  return (
+    <div className="saved-address-selector mb-6">
+      <p className="text-sm font-medium mb-3">{_('Use a saved address')}</p>
+      <RadioGroup value={currentValue} onValueChange={handleValueChange}>
+        {addresses.map((addr) => (
+          <Item key={addr.uuid ?? addr.addressId} variant="outline">
+            <ItemContent>
+              <ItemTitle>
+                <div className="flex items-center space-x-3">
+                  <RadioGroupItem
+                    id={`saved-addr-${addr.uuid ?? addr.addressId}`}
+                    value={addr.uuid ?? String(addr.addressId)}
+                  />
+                  <Label htmlFor={`saved-addr-${addr.uuid ?? addr.addressId}`}>
+                    {addr.fullName}
+                  </Label>
+                </div>
+              </ItemTitle>
+              <ItemDescription className="text-inherit mt-1 line-clamp-none">
+                <div className="pl-7 text-sm text-muted-foreground space-y-0.5">
+                  {addr.address1 && <div>{addr.address1}</div>}
+                  {addr.address2 && <div>{addr.address2}</div>}
+                  <div>
+                    {[addr.city, addr.province?.name, addr.postcode]
+                      .filter(Boolean)
+                      .join(', ')}
+                  </div>
+                  {addr.country && <div>{addr.country.name}</div>}
+                  {addr.telephone && <div>{addr.telephone}</div>}
+                </div>
+              </ItemDescription>
+            </ItemContent>
+          </Item>
+        ))}
+
+        <Item variant="outline">
+          <ItemContent>
+            <ItemTitle>
+              <div className="flex items-center space-x-3">
+                <RadioGroupItem id="saved-addr-new" value="new" />
+                <Label htmlFor="saved-addr-new">
+                  {_('Or enter a new address')}
+                </Label>
+              </div>
+            </ItemTitle>
+          </ItemContent>
+        </Item>
+      </RadioGroup>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

As a user, I need to have 2 (or more) addresses saved to my account so I can quickly select them during checkout without re-entering address details each time.

## Acceptance Criteria

- Users can store and manage multiple addresses in their account (Address Book)
- During checkout (shipping and billing), users can select from their saved addresses
- Selecting a saved address auto-fills the checkout form fields
- Users can still choose to enter a new address at checkout

## Changes Summary

### New File
- **`SavedAddressSelector.tsx`** — New React component that renders a radio-button list of the customer's saved addresses during checkout. Includes an "Or enter a new address" option to allow manual entry.

### Modified Files
- **`Shipment.tsx`** — Integrated `SavedAddressSelector` into the shipping address step. When a logged-in customer has saved addresses, the selector appears above the address form. Selecting an address auto-populates all shipping fields via `react-hook-form`.

- **`BillingAddress.tsx`** — Same integration as Shipment for the billing address step. Works for both "use different billing address" and "enter billing address" modes.

### Pre-existing Backend Support
The following were already in place and required no changes:
- **Database**: `customer_address` table supports multiple addresses per user (with `uuid`, `is_default`, FK to `customer`)
- **GraphQL**: `Customer.addresses: [CustomerAddress]` query already returns all saved addresses
- **REST API**: Create (`POST`), Update (`PATCH`), Delete (`DELETE`) endpoints for customer addresses
- **Account UI**: `MyAddresses` component on the `/account` page allows full CRUD management of saved addresses